### PR TITLE
#8: Refactored allow contract

### DIFF
--- a/assembly/allow/allow.contract.ts
+++ b/assembly/allow/allow.contract.ts
@@ -92,10 +92,30 @@ export class AllowContract extends Contract {
     /**
      * Helper functions
      */
-    findAllowedToken(token: ExtendedSymbol): AllowedToken | null {
+
+    protected checkContractIsNotPaused(): void {
+        check(!this.isContractPaused(), `Contract ${this.contract} is paused`)
+    }
+
+    protected checkActorIsAllowed(actor: Name, message: string): void {
+        if (!message) {
+            message = `Actor '${actor}' is not allowed to use contract '${this.contract}'`;
+        }
+        check(this.isActorAllowed(actor), message);
+    }
+
+    protected checkTokenIsAllowed(token: ExtendedSymbol, message: string): void {
+        if (!message) {
+            message = `Token '${token}' is not allowed to use contract '${this.contract}'`;
+        }
+        check(this.isTokenAllowed(token), message);
+    }
+
+    private findAllowedToken(token: ExtendedSymbol): AllowedToken | null {
         return this.allowedTokenTable.getBySecondaryIDX128(extendedSymbolToU128(token), 0)
     }
-    isTokenAllowed(token: ExtendedSymbol): boolean {
+
+    private isTokenAllowed(token: ExtendedSymbol): boolean {
         // Check stricst
         const isTokenStrict = this.allowGlobalsSingleton.get().isTokenStrict
 
@@ -110,11 +130,8 @@ export class AllowContract extends Contract {
         // Check is blocked
         return allowedToken.isAllowed || (!isTokenStrict && !allowedToken.isBlocked)
     }
-    checkTokenIsAllowed(token: ExtendedSymbol): void {
-        check(this.isTokenAllowed(token), `Token ${token} is now allowed to use ${this.contract}`)
-    }
 
-    isActorAllowed(actor: Name): boolean {
+    private isActorAllowed(actor: Name): boolean {
         // Check stricst
         const isActorStrict = this.allowGlobalsSingleton.get().isActorStrict
 
@@ -129,14 +146,8 @@ export class AllowContract extends Contract {
         // Check is blocked
         return allowedActor.isAllowed || (!isActorStrict && !allowedActor.isBlocked)
     }
-    checkActorIsAllowed(actor: Name): void {
-        check(this.isActorAllowed(actor), `Actor ${actor} is now allowed to use ${this.contract}`)
-    }
 
-    isContractPaused(): boolean {
+    private isContractPaused(): boolean {
         return this.allowGlobalsSingleton.get().isPaused
-    }
-    checkContractIsNotPaused(): void {
-        check(!this.isContractPaused(), `Contract ${this.contract} is paused`)
     }
 }

--- a/assembly/allow/allow_test.contract.ts
+++ b/assembly/allow/allow_test.contract.ts
@@ -1,0 +1,30 @@
+import { Name, ExtendedSymbol } from '..'
+import { AllowContract } from '.';
+
+@contract
+export class AllowTestContract extends AllowContract {
+    /**
+     * Helper actions
+     */
+
+    @action("testpaused")
+    testpaused(): void {
+        this.checkContractIsNotPaused()
+    }
+
+    @action("testactor")
+    testactor(
+        actor: Name,
+        message: string
+    ): void {
+        this.checkActorIsAllowed(actor, message);
+    }
+
+    @action("testtoken")
+    testtoken(
+        token: ExtendedSymbol,
+        message: string
+    ): void {
+        this.checkTokenIsAllowed(token, message)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:token": "npx proton-asc ./assembly/token/token.contract.ts",
     "build:balance": "npx proton-asc ./assembly/balance/balance.contract.ts",
     "build:escrow": "npx proton-asc ./assembly/escrow/escrow.contract.ts",
-    "build:allow": "npx proton-asc ./assembly/allow/allow.contract.ts",
+    "build:allow": "npx proton-asc ./assembly/allow/allow.contract.ts && npx proton-asc ./assembly/allow/allow_test.contract.ts",
     "build:atomicassets": "npx proton-asc ./assembly/atomicassets/atomicassets.contract.ts --debug --sourceMap --target release",
     "build:store": "npx proton-asc ./assembly/modules/store/store.test.ts",
     "build:safemath": "npx proton-asc ./assembly/modules/safemath/safemath.test.ts",


### PR DESCRIPTION
Added allow-test contract to perform tests for internal methods
Improved and implemented tests for the contract

Closes #8 